### PR TITLE
added webhook verification in resources package

### DIFF
--- a/resources/verify_webhook_signature.go
+++ b/resources/verify_webhook_signature.go
@@ -1,0 +1,44 @@
+package resources
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"io/ioutil"
+)
+
+// This function takes in the raw request body and returns a byte slice to be used in json unmarshalling
+/* Usage
+
+body, err := client.resources.VerifyWebhookSignature(r.Body, webhookSignature, webhookSecret)
+if err != nil {
+	 # Handle error
+}
+
+# Proceed with further processing. Eg: JSON unmarshalling
+
+json.Unmarshal(body, &variable)
+
+*/
+func VerifyWebhookSignature(requestBody io.ReadCloser, webhookSignature string, webhookSecret string) ([]byte, error) {
+	body, err := ioutil.ReadAll(requestBody)
+	if err != nil {
+		return nil, err
+	}
+	if err := VerifySignature(body, webhookSignature, webhookSecret); err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+func VerifySignature(body []byte, signature string, key string) error {
+	h := hmac.New(sha256.New, []byte(key))
+	h.Write(body)
+	expectedSignature := hex.EncodeToString(h.Sum(nil))
+	if expectedSignature != signature {
+		return errors.New("Signatures don't match")
+	}
+	return nil
+}


### PR DESCRIPTION
I have implemented the webhook signature verification as mentioned in  [Issue 18](https://github.com/razorpay/razorpay-go/issues/18). 

Since request body is of type io.ReadCloser and cannot be read again, I have written the  function such that it returns a byte slice of the request body so that it can be used for further processing. 

Hope this is useful. Feedback appreciated.