### PR TITLE
fixes #22

### DIFF
--- a/errors/rzperrors.go
+++ b/errors/rzperrors.go
@@ -37,29 +37,31 @@ type SignatureVerificationError struct {
 	Err     error
 }
 
-func handleError(msg string, desc string) string {
+func handleError(msg string, err error) string {
 	errorMessage := ""
 	if msg != "" {
 		errorMessage += msg
 	}
-	errorMessage += desc
+	if err != nil {
+		errorMessage += err.Error()
+	}
 	return errorMessage
 }
 
 //Error ...
 func (s *BadRequestError) Error() string {
-	return handleError(s.Message, s.Err.Error())
+	return handleError(s.Message, s.Err)
 }
 
 func (s *GatewayError) Error() string {
-	return handleError(s.Message, s.Err.Error())
+	return handleError(s.Message, s.Err)
 
 }
 
 func (s *ServerError) Error() string {
-	return handleError(s.Message, s.Err.Error())
+	return handleError(s.Message, s.Err)
 }
 
 func (s *SignatureVerificationError) Error() string {
-	return handleError(s.Message, s.Err.Error())
+	return handleError(s.Message, s.Err)
 }

--- a/requests/request.go
+++ b/requests/request.go
@@ -117,7 +117,7 @@ func (request *Request) doRequestResponse(req *http.Request) (map[string]interfa
 
 	// Raise an error depending on the type of error in response
 	var jsonResponse errors.RZPErrorJSON
-	json.NewDecoder(response.Body).Decode(jsonResponse)
+	json.NewDecoder(response.Body).Decode(&jsonResponse)
 	errorData := jsonResponse.ErrorData
 
 	switch errorData.InternalErrorCode {


### PR DESCRIPTION
 - Error methods of Error structs previously did not
    check if err is nil, this caused nil pointer dereference error
 - doRequestResponse function previously did not decode
    Error Message

I was getting nil pointer dereference error when trying to create Transfer of amount greater than current razorpay account balance.
This issue fixes this too.