### PR TITLE
fix: handling query param arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Query parameter handling in URLs
+- Custom User Agent in headers
 
 ## [1.3.3] - 2025-05-02
 feat: Added new API endpoints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.3.4] - 2024-07-15
+## [1.3.4] - 2025-05-07
 
 ### Added
 - Unit tests for `buildURLWithParams` function in requests package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.4] - 2024-07-15
+
+### Added
+- Unit tests for `buildURLWithParams` function in requests package
+
+### Fixed
+- Query parameter handling in URLs
+
 ## [1.3.3] - 2025-05-02
 feat: Added new API endpoints
 - Added Payout API:

--- a/client.go
+++ b/client.go
@@ -9,10 +9,10 @@ import (
 	"github.com/razorpay/razorpay-go/resources"
 )
 
-//Request ...
+// Request ...
 var Request *requests.Request
 
-//Client provides various helper methods to make HTTP requests to Razorpay's APIs.
+// Client provides various helper methods to make HTTP requests to Razorpay's APIs.
 type Client struct {
 	Addon          *resources.Addon
 	Account        *resources.Account
@@ -116,6 +116,10 @@ func (client *Client) AddHeaders(headers map[string]string) {
 // be overridden for all HTTP requests made using this client.
 func (client *Client) SetTimeout(timeout int16) {
 	Request.SetTimeout(timeout)
+}
+
+func (client *Client) SetUserAgent(userAgent string) {
+	Request.SetUserAgent(userAgent)
 }
 
 func getVersion() string {

--- a/constants/headers.go
+++ b/constants/headers.go
@@ -1,0 +1,6 @@
+package constants
+
+const (
+	UserAgentHeader   = "User-Agent"
+	ContentTypeHeader = "Content-Type"
+)

--- a/requests/request.go
+++ b/requests/request.go
@@ -18,7 +18,7 @@ import (
 	"github.com/razorpay/razorpay-go/errors"
 )
 
-//Auth holds the values required to authenticate the requests made to Razorpay APIs
+// Auth holds the values required to authenticate the requests made to Razorpay APIs
 type Auth struct {
 	Key    string
 	Secret string
@@ -29,7 +29,7 @@ type FileUploadParams struct {
 	Fields map[string]string
 }
 
-//TIMEOUT ... client timeout
+// TIMEOUT ... client timeout
 const TIMEOUT = 10
 
 // Request encapsulates all the information required to make an HTTP request
@@ -56,6 +56,16 @@ func buildURLWithParams(requestURL string, data map[string]interface{}) string {
 	parameters := url.Values{}
 
 	for k, v := range data {
+		// Handle string arrays specially to follow the format key[]=val1&key[]=val2
+		// This is a common pattern in rzp APIs
+		if stringArray, isStringArray := v.([]string); isStringArray {
+			for _, item := range stringArray {
+				parameters.Add(k, item)
+			}
+			continue
+		}
+
+		// Default case for all other types
 		parameters.Add(k, fmt.Sprintf("%v", v))
 	}
 
@@ -97,7 +107,7 @@ func (request *Request) addRequestHeaders(req *http.Request, headers map[string]
 	request.addRequestHeadersInternal(req, headers)
 }
 
-//SetTimeout ...
+// SetTimeout ...
 func (request *Request) SetTimeout(timeout int16) {
 	timeoutSeconds := int64(timeout) * int64(time.Second)
 	request.HTTPClient = &http.Client{Timeout: time.Duration(timeoutSeconds)}
@@ -155,7 +165,7 @@ func (request *Request) doRequestResponse(req *http.Request) (map[string]interfa
 	return processResponse(response)
 }
 
-//Get ...
+// Get ...
 func (request *Request) Get(path string, queryParams map[string]interface{}, extraHeaders map[string]string) (map[string]interface{}, error) {
 	url := fmt.Sprintf("%s%s", request.BaseURL, path)
 
@@ -170,7 +180,7 @@ func (request *Request) Get(path string, queryParams map[string]interface{}, ext
 	return request.doRequestResponse(req)
 }
 
-//Post ...
+// Post ...
 func (request *Request) Post(path string, payload map[string]interface{}, extraHeaders map[string]string) (map[string]interface{}, error) {
 
 	jsonStr, _ := json.Marshal(payload)
@@ -186,7 +196,7 @@ func (request *Request) Post(path string, payload map[string]interface{}, extraH
 	return request.doRequestResponse(req)
 }
 
-//Patch ...
+// Patch ...
 func (request *Request) Patch(path string, payload map[string]interface{}, extraHeaders map[string]string) (map[string]interface{}, error) {
 
 	jsonStr, _ := json.Marshal(payload)
@@ -202,7 +212,7 @@ func (request *Request) Patch(path string, payload map[string]interface{}, extra
 	return request.doRequestResponse(req)
 }
 
-//Put ...
+// Put ...
 func (request *Request) Put(path string, payload map[string]interface{}, extraHeaders map[string]string) (map[string]interface{}, error) {
 
 	jsonStr, _ := json.Marshal(payload)
@@ -218,7 +228,7 @@ func (request *Request) Put(path string, payload map[string]interface{}, extraHe
 	return request.doRequestResponse(req)
 }
 
-//Delete ...
+// Delete ...
 func (request *Request) Delete(path string, queryParams map[string]interface{}, extraHeaders map[string]string) (map[string]interface{}, error) {
 
 	url := fmt.Sprintf("%s%s", request.BaseURL, path)

--- a/requests/request_test.go
+++ b/requests/request_test.go
@@ -78,3 +78,66 @@ func TestBuildURLWithParams(t *testing.T) {
 		})
 	}
 }
+
+func TestGetUserAgentHeaderValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		request  Request
+		expected string
+	}{
+		{
+			name: "empty user agent",
+			request: Request{
+				SDKName:   "razorpay-go",
+				Version:   "1.3.4",
+				userAgent: "",
+			},
+			expected: "razorpay-go/1.3.4",
+		},
+		{
+			name: "custom user agent",
+			request: Request{
+				SDKName:   "razorpay-go",
+				Version:   "1.3.4",
+				userAgent: "CustomApp/2.0",
+			},
+			expected: "CustomApp/2.0 (razorpay-go/1.3.4)",
+		},
+		{
+			name: "user agent with spaces",
+			request: Request{
+				SDKName:   "razorpay-go",
+				Version:   "1.3.4",
+				userAgent: "Custom Application 2.0",
+			},
+			expected: "Custom Application 2.0 (razorpay-go/1.3.4)",
+		},
+		{
+			name: "different SDK version",
+			request: Request{
+				SDKName:   "razorpay-go",
+				Version:   "2.0.0",
+				userAgent: "CustomApp/2.0",
+			},
+			expected: "CustomApp/2.0 (razorpay-go/2.0.0)",
+		},
+		{
+			name: "different SDK name",
+			request: Request{
+				SDKName:   "razorpay-custom",
+				Version:   "1.3.4",
+				userAgent: "CustomApp/2.0",
+			},
+			expected: "CustomApp/2.0 (razorpay-custom/1.3.4)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.request.getUserAgentHeaderValue()
+			if result != tt.expected {
+				t.Errorf("getUserAgentHeaderValue() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/requests/request_test.go
+++ b/requests/request_test.go
@@ -1,0 +1,80 @@
+package requests
+
+import (
+	"testing"
+)
+
+func TestBuildURLWithParams(t *testing.T) {
+	tests := []struct {
+		name       string
+		requestURL string
+		data       map[string]interface{}
+		expected   string
+	}{
+		{
+			name:       "basic URL with simple parameters",
+			requestURL: "https://api.razorpay.com/v1/payments",
+			data: map[string]interface{}{
+				"count": 10,
+				"skip":  20,
+			},
+			expected: "https://api.razorpay.com/v1/payments?count=10&skip=20",
+		},
+		{
+			name:       "URL with existing query parameters",
+			requestURL: "https://api.razorpay.com/v1/payments?expand=1",
+			data: map[string]interface{}{
+				"count": 10,
+			},
+			expected: "https://api.razorpay.com/v1/payments?count=10",
+		},
+		{
+			name:       "parameters with special characters",
+			requestURL: "https://api.razorpay.com/v1/payments",
+			data: map[string]interface{}{
+				"merchant": "ABC & Co.",
+			},
+			expected: "https://api.razorpay.com/v1/payments?merchant=ABC+%26+Co.",
+		},
+		{
+			name:       "parameters with string array values",
+			requestURL: "https://api.razorpay.com/v1/payments",
+			data: map[string]interface{}{
+				"ids[]": []string{"pay_123", "pay_456", "pay_789"},
+			},
+			expected: "https://api.razorpay.com/v1/payments?ids%5B%5D=pay_123&ids%5B%5D=pay_456&ids%5B%5D=pay_789",
+		},
+		{
+			name:       "empty parameters",
+			requestURL: "https://api.razorpay.com/v1/payments",
+			data:       map[string]interface{}{},
+			expected:   "https://api.razorpay.com/v1/payments",
+		},
+		{
+			name:       "nil parameters handled as empty",
+			requestURL: "https://api.razorpay.com/v1/payments",
+			data:       nil,
+			expected:   "https://api.razorpay.com/v1/payments",
+		},
+		{
+			name:       "mixed parameter types",
+			requestURL: "https://api.razorpay.com/v1/payments",
+			data: map[string]interface{}{
+				"count":    10,
+				"active":   true,
+				"keywords": []string{"success", "authorized"},
+				"amount":   1999.99,
+			},
+			expected: "https://api.razorpay.com/v1/payments?active=true&amount=1999.99&count=10&keywords=success&keywords=authorized",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildURLWithParams(tt.requestURL, tt.data)
+			if result != tt.expected {
+				t.Errorf("buildURLWithParams() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/version.go
+++ b/version.go
@@ -1,7 +1,7 @@
 package razorpay
 
-//SDKName ...Name of this SDK
+// SDKName ...Name of this SDK
 const SDKName = "razorpay-go"
 
-//SDKVersion ...
-const SDKVersion = "1.3.3"
+// SDKVersion ...
+const SDKVersion = "1.3.4"


### PR DESCRIPTION
Change to handle string arrays specially to follow the format key[]=val1&key[]=val2
This is a common pattern in rzp APIs

