### PR TITLE
chore: upgrade Go version to 1.26 and update dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.22'
+          go-version: '1.26'
 
       - name: Run coverage
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18'
+          go-version: '1.22'
 
       - name: Run coverage
         run: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/razorpay/razorpay-go
 
-go 1.22
+go 1.26
 
 require github.com/stretchr/testify v1.11.1
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,11 @@
 module github.com/razorpay/razorpay-go
 
-go 1.14
+go 1.22
 
-require github.com/stretchr/testify v1.5.1
+require github.com/stretchr/testify v1.11.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,10 @@
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
-github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/requests/request.go
+++ b/requests/request.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"mime/multipart"
 	"net/http"
@@ -155,7 +154,7 @@ func (request *Request) setAuthentication(req *http.Request) {
 
 func processResponse(response *http.Response) (map[string]interface{}, error) {
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 
 	if len(body) == 0 || len(body) == 2 {
 		resp := make(map[string]interface{})

--- a/resources/account_test.go
+++ b/resources/account_test.go
@@ -3,7 +3,7 @@ package resources_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -28,7 +28,7 @@ func TestAccountCreate(t *testing.T) {
 	url := "/v2" + constants.ACCOUNT_URL
 	teardown, fixture := utils.StartMockServer(url, "fake_account")
 	defer teardown()
-	b, err := ioutil.ReadFile("../testdata/fake_account_request.json")
+	b, err := os.ReadFile("../testdata/fake_account_request.json")
 	if err != nil {
 		panic(err)
 	}

--- a/resources/stakeholder_test.go
+++ b/resources/stakeholder_test.go
@@ -3,7 +3,7 @@ package resources_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -30,7 +30,7 @@ func TestStakeholderCreate(t *testing.T) {
 
 	teardown, fixture := utils.StartMockServer(url, "fake_stakeholder")
 	defer teardown()
-	b, err := ioutil.ReadFile("../testdata/stakeholder_data.json")
+	b, err := os.ReadFile("../testdata/stakeholder_data.json")
 	if err != nil {
 		panic(err)
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -6,9 +6,9 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -47,7 +47,7 @@ func testSetup() func() {
 
 func getFixture(path string) string {
 	filepath := path + ".json"
-	b, err := ioutil.ReadFile("../testdata/" + filepath)
+	b, err := os.ReadFile("../testdata/" + filepath)
 	if err != nil {
 		panic(err)
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -85,7 +85,7 @@ func StartMockServer(url string, fixtureName string) (func(), string) {
 	mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, fixture) // nosemgrep : go.lang.security.audit.xss.no-fprintf-to-responsewriter.no-fprintf-to-responsewriter
+		fmt.Fprint(w, fixture)
 	})
 	return teardown, fixture
 }


### PR DESCRIPTION
- Upgrade minimum Go version from 1.14 to 1.26
- Update testify from v1.5.1 to v1.11.1
- Replace deprecated ioutil with io and os packages
- Update CI workflow to use Go 1.26

## Note :- Please follow the below points while attaching test cases document link below:
   ### - If label `Tested` is added then test cases document URL is mandatory.
   ### - Link added should be a valid URL and accessible throughout the org.
   ### - If the branch name contains hotfix / revert by default the BVT workflow check will pass.

| Test Case Document URL                        |
|-----------------------------------------------|
https://docs.google.com/document/d/14EreOpFhkJlQPVSvExz6ratF1Hg_rmTPHKKnSnJyCCk/edit?usp=sharing
