### PR TITLE
fix: use constant-time comparison for signature verification

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -130,9 +130,14 @@ func VerifyPaymentLinkSignature(queryParams map[string]interface{}, webhookSigna
 func VerifySignature(body []byte, signature string, key string) bool {
 	h := hmac.New(sha256.New, []byte(key))
 	h.Write(body)
-	expectedSignature := hex.EncodeToString(h.Sum(nil))
-	if expectedSignature != signature {
+	expectedSignature := h.Sum(nil)
+
+	// Decode the provided signature from hex
+	signatureBytes, err := hex.DecodeString(signature)
+	if err != nil {
 		return false
 	}
-	return true
+
+	// Use constant-time comparison to prevent timing attacks
+	return hmac.Equal(expectedSignature, signatureBytes)
 }


### PR DESCRIPTION
Replace timing-vulnerable string comparison (!=) with hmac.Equal() to prevent timing attacks on signature verification.

The previous implementation used string comparison which short-circuits on the first mismatched character, potentially leaking information about the expected signature through response time differences.

hmac.Equal() compares byte slices in constant time, preventing attackers from guessing signatures character-by-character through timing analysis.

Affects: VerifyWebhookSignature, VerifyPaymentSignature, VerifySubscriptionSignature, VerifyPaymentLinkSignature

## Note :- Please follow the below points while attaching test cases document link below:
   ### - If label `Tested` is added then test cases document URL is mandatory.
   ### - Link added should be a valid URL and accessible throughout the org.
   ### - If the branch name contains hotfix / revert by default the BVT workflow check will pass.

| Test Case Document URL                        |
|-----------------------------------------------|
https://docs.google.com/document/d/15Wb6wl531glbWuanSpBkR93FClDJOWY5qGn43MGyHjc/edit?tab=t.0
