### PR TITLE
chore: upgrade Go to v1.26 and update dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     name: Run tests and publish test coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.26'
 

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,10 @@ module github.com/razorpay/razorpay-go
 
 go 1.26
 
-require github.com/stretchr/testify v1.11.1
+require github.com/stretchr/testify v1.5.1
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v2 v2.2.2 // indirect
 )


### PR DESCRIPTION
- Update Go version from EOL versions ((see git diff)) to v1.26
- Update GitHub Actions to current versions:
  - .github/workflows/ci.yml: actions/checkout@v2 → actions/checkout@v4
  - .github/workflows/ci.yml: actions/setup-go@v2 → actions/setup-go@v5
- Update CI matrix to use new runtime versions
- Reduces audit vulnerabilities from 0 to 0


## Note :- Please follow the below points while attaching test cases document link below:
   ### - If label `Tested` is added then test cases document URL is mandatory.
   ### - Link added should be a valid URL and accessible throughout the org.
   ### - If the branch name contains hotfix / revert by default the BVT workflow check will pass.

| Test Case Document URL                        |
|-----------------------------------------------|
| Please paste test case document link here.... |
