### PR TITLE
Fix wrong URL in Webhook.Edit v1 path (uses accountId instead of webhookId)

### DIFF
--- a/resources/webhook_test.go
+++ b/resources/webhook_test.go
@@ -74,3 +74,19 @@ func TestWebhookEdit(t *testing.T) {
 	assert.Equal(t, err, nil)
 	utils.TestResponse(jsonByteArray, []byte(fixture), t)
 }
+
+func TestWebhookEditV1(t *testing.T) {
+	// When no accountId is supplied, the v1 endpoint must address the webhook
+	// being edited: /v1/webhooks/{webhookId}
+	url := "/" + constants.VERSION_V1 + constants.WEBHOOK + "/" + TestWebhookID
+	teardown, fixture := utils.StartMockServer(url, "fake_webhook")
+	defer teardown()
+
+	data := map[string]interface{}{
+		"url": "https://www.linkedin.com",
+	}
+	body, err := utils.Client.Webhook.Edit(TestWebhookID, "", data, nil)
+	jsonByteArray, _ := json.Marshal(body)
+	assert.Equal(t, err, nil)
+	utils.TestResponse(jsonByteArray, []byte(fixture), t)
+}

--- a/resources/webhooks.go
+++ b/resources/webhooks.go
@@ -35,7 +35,7 @@ func (wh *Webhook) Edit(webhookId string, accountId string, data map[string]inte
 		url := fmt.Sprintf("/%s%s/%s%s/%s", constants.VERSION_V2, constants.ACCOUNT_URL, url.PathEscape(accountId), constants.WEBHOOK, url.PathEscape(webhookId))
 		return wh.Request.Patch(url, data, extraHeaders)
 	}
-	url := fmt.Sprintf("/%s%s/%s", constants.VERSION_V1, constants.WEBHOOK, url.PathEscape(accountId))
+	url := fmt.Sprintf("/%s%s/%s", constants.VERSION_V1, constants.WEBHOOK, url.PathEscape(webhookId))
 	return wh.Request.Put(url, data, extraHeaders)
 }
 


### PR DESCRIPTION
## Summary

`Webhook.Edit` builds the **v1** (non-account) request URL with `url.PathEscape(accountId)` instead of `webhookId`:

```go
url := fmt.Sprintf("/%s%s/%s", constants.VERSION_V1, constants.WEBHOOK, url.PathEscape(accountId))
```

That branch is only reached when `accountId == ""`, so the webhook id is omitted entirely and the request goes to `/v1/webhooks/` instead of `/v1/webhooks/{webhookId}` — no webhook is addressed, and the update fails / targets the wrong resource.

## Root cause

Copy-paste: `accountId` used where `webhookId` was intended. `TestWebhookEdit` only exercises the **v2** account path (non-empty `accountId`), so the v1 branch was never covered.

## Fix

Interpolate `webhookId`. Added `TestWebhookEditV1` covering the v1 path — it **fails without** this change (request hits `/v1/webhooks/`, mock 404) and **passes with** it. Full `go test ./...` green.
