### PR TITLE
chore: add stale PR cleanup workflow via centralized pr-manager

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,8 @@
+name: PR Manager
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * *'
+jobs:
+  pr-manager:
+    uses: razorpay/actions/.github/workflows/pr-manager.yaml@main

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,8 +1,13 @@
+# PR Manager — stale PR cleanup via centralized reusable workflow in razorpay/actions.
+# See: https://github.com/razorpay/actions/blob/master/.github/workflows/pr-manager.yaml
 name: PR Manager
+
 on:
-  workflow_dispatch:
   schedule:
-    - cron: '0 2 * * *'
+    - cron: '30 20 * * *'   # 2:00 AM IST (8:30 PM UTC)
+  workflow_dispatch: {}
+
 jobs:
-  pr-manager:
-    uses: razorpay/actions/.github/workflows/pr-manager.yaml@main
+  stale:
+    uses: razorpay/actions/.github/workflows/pr-manager.yaml@master
+    secrets: inherit


### PR DESCRIPTION
Adds centralized PR Manager workflow that delegates stale PR cleanup to `razorpay/actions/.github/workflows/pr-manager.yaml`.